### PR TITLE
docs: add link to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ weight: 10
 
 # Enhancements
 
-This repository contains design proposals for [Jenkins X](https://jenkins-x.io/) enhancements.
+The [enhancements repository](https://github.com/jenkins-x/enhancements) contains design proposals for [Jenkins X](https://jenkins-x.io/) enhancements.
 
 All proposals are welcome, please follow this process:
 


### PR DESCRIPTION
This is not a change which manifestly improves this README. However, this README is getting pulled in as a submodule to Jenkins X docs and on the page there, it is very helpful to have the link back to this repository.